### PR TITLE
Enable apache2 should not start the service just yet

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,5 +52,4 @@
 - name: enable apache2
   service:
     name: apache2
-    state: started
     enabled: yes


### PR DESCRIPTION
The role currently does not setup any sites, so starting apache before another role/play creates the site could result in an error. To be safe, we can avoid starting apache2 just yet, only make sure it is enabled. Then the handlers will run at the end of the play once the configuration is complete.