### PR TITLE
Add tmpfiles.d for apache2 runtime dir

### DIFF
--- a/files/usr_lib_tmpfiles_d_apache2.conf
+++ b/files/usr_lib_tmpfiles_d_apache2.conf
@@ -1,0 +1,1 @@
+d /var/run/apache2 0755 root root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,9 @@
     line: 'ServerSignature Off'
   notify: reload apache
 
+- name: Create /var/run/apache2 with correct umask on startup
+  copy: src=usr_lib_tmpfiles_d_apache2.conf dest=/usr/lib/tmpfiles.d/apache2.conf mode=0644 owner=root group=root
+
 - name: enable apache2 mod_wsgi config to use custom python
   template: src=etc/apache2/conf-enabled/wsgi-custom-python.conf.j2 dest=/etc/apache2/conf-enabled/wsgi-custom-python.conf mode=0644
   notify: reload apache


### PR DESCRIPTION
The hardening playbook sets a global umask 027, so when the system daemon
creates /var/run/apache2, it's not readable by www-data and apache cannot
connect to the wsgi socket. The tmpfiles.d config will ensure the runtime dir is
created on startup with the correct mode.