### PR TITLE
Disable /var/www Indexes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Configure /var/www with -Indexes
+apache2_disable_var_www_indexes: true
+
 # Versions of SSL to support
 apache2_ssl_versions:
   - TLSv1.1

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -3,15 +3,29 @@
   hosts: all
   roles:
     - role: datagov-deploy-apache2
-      python_home: /usr/local
+      # We use an existing prefix where python is
+      # installed. Otherwise Apache/wsgi won't start up
+      # properly.
+      python_home: /usr
   tasks:
+    - name: create docroot
+      file: dest=/www state=directory
+
+    - name: copy custom index
+      copy:
+        content: |
+          <h1>Hello World</h1>
+        dest: /www/index.html
+      notify: reload apache
+
     - name: copy custom site
       copy:
         content: |
           <VirtualHost 0.0.0.0:80>
-            <Location />
-               Return 200
-            </Location>
+            DocumentRoot /www
+            <Directory /www>
+              Require all granted
+            </Directory>
           </VirtualHost>
-        dest: /etc/apache2/sites-enabled/custom
+        dest: /etc/apache2/sites-enabled/custom.conf
       notify: reload apache

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -5,7 +5,7 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
-python_prefix = '/usr/local'
+python_prefix = '/usr'
 
 
 def test_wsgi_python_home(host):
@@ -26,10 +26,31 @@ def test_apache2(host):
     assert service.is_running
 
 
-def test_ports(host):
+def test_http(host):
     http = host.socket('tcp://80')
 
     assert http.is_listening
+
+
+def test_https(host):
+    https = host.socket('tcp://443')
+
+    assert https.is_listening
+
+
+def test_www(host):
+    uri = host.ansible('uri', 'url="http://localhost/"', check=False)
+
+    assert uri['status'] == 200
+
+
+def test_no_indexes(host):
+    # Test we don't get an Indexes/MultiView from http://localhost:443
+    # TODO we should set up the role to assume redirect http -> https which
+    # would remove the need for this.
+    uri = host.ansible('uri', 'url="http://localhost:443/?M=A"', check=False)
+
+    assert uri['status'] == 403
 
 
 def test_ssl_versions(host):

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,14 @@
   template: src=templates/etc/apache2/conf-enabled/mod_remoteip.conf dest=/etc/apache2/conf-enabled/mod_remoteip.conf mode=0644
   notify: reload apache
 
+- name: Disable /var/www
+  template: >-
+    src=templates/etc/apache2/conf-enabled/disable-var-www-indexes.conf
+    dest=/etc/apache2/conf-enabled/disable-var-www-indexes.conf
+    mode=0644
+  when: apache2_disable_var_www_indexes
+  notify: reload apache
+
 - name: Apache ServerTokens Prod
   lineinfile:
     dest: /etc/apache2/conf-enabled/security.conf

--- a/templates/etc/apache2/conf-enabled/disable-var-www-indexes.conf
+++ b/templates/etc/apache2/conf-enabled/disable-var-www-indexes.conf
@@ -1,0 +1,9 @@
+# apache2.conf configures /var/www to be served from http://localhost:443. This
+# is perceived as an infomration disclosure by scanners, even if /var/www is
+# unused. We disable Indexes here. It can be disabled with
+#
+#     apache2_disable_var_www_indexes: true
+#
+<Directory /var/www>
+  Options -Indexes
+</Directory>


### PR DESCRIPTION
Fixess Nessus 10704

This is more of a quirk than anything. We listen on http but nessus scans on
https. MultiViews aren't actually enabled, but Nessus sees the Indexes and lumps
it in with Multiviews Arbitrary Directory Listing.

If we just listed on https, we wouldn't need this.