### PR TITLE
Configure TLS/SSL certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ and enable them with `a2ensite`.
 
 ### Variables
 
+**`apache2_ssl_certificate_file`** string (default: none)
+
+File path to the TLS/SSL certificate file.
+
+**`apache2_ssl_certificate_key_file`** string (default: none)
+
+File path to the TLS/SSL certificate key file.
+
 **`apache2_ssl_ciphers`** string (default: `HIGH:!aNULL:!MD5`)
 
 SSL cipher string to support for mod_ssl.
@@ -52,6 +60,10 @@ Install dependencies.
 Run the tests.
 
     $ make test
+
+To run the ssl scenario playbook with molecule.
+
+    $ molecule converge -s ssl
 
 For more information on how to use
 [Molecule](https://molecule.readthedocs.io/en/latest/) for development, see [our

--- a/molecule/ssl/Dockerfile.j2
+++ b/molecule/ssl/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates && xbps-remove -O; fi

--- a/molecule/ssl/INSTALL.rst
+++ b/molecule/ssl/INSTALL.rst
@@ -1,0 +1,16 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* General molecule dependencies (see https://molecule.readthedocs.io/en/latest/installation.html)
+* Docker Engine
+* docker-py
+* docker
+
+Install
+=======
+
+    $ sudo pip install docker-py

--- a/molecule/ssl/molecule.yml
+++ b/molecule/ssl/molecule.yml
@@ -1,0 +1,20 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: apache2
+    image: ubuntu:trusty
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+scenario:
+  name: ssl
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/ssl/playbook.yml
+++ b/molecule/ssl/playbook.yml
@@ -1,0 +1,8 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    apache2_ssl_certificate_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
+    apache2_ssl_certificate_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
+  roles:
+    - role: datagov-deploy-apache2

--- a/molecule/ssl/tests/test_default.py
+++ b/molecule/ssl/tests/test_default.py
@@ -1,0 +1,18 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_ssl_conf(host):
+    f = host.file('/etc/apache2/mods-available/ssl.conf')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'
+    assert f.contains(
+        'SSLCertificateFile /etc/ssl/certs/ssl-cert-snakeoil.pem')
+    assert f.contains(
+        'SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,20 @@
     line: 'ServerSignature Off'
   notify: reload apache
 
+- name: Configure TLS/SSL certificate
+  lineinfile:
+    dest: /etc/apache2/mods-enabled/ssl.conf
+    regexp: '^SSLCertificateFile'
+    line: SSLCertificateFile {{ apache2_ssl_certificate_file }}
+  when: apache2_ssl_certificate_file is defined
+
+- name: Configure TLS/SSL certificate key
+  lineinfile:
+    dest: /etc/apache2/mods-enabled/ssl.conf
+    regexp: '^SSLCertificateKeyFile'
+    line: SSLCertificateKeyFile {{ apache2_ssl_certificate_key_file }}
+  when: apache2_ssl_certificate_key_file is defined
+
 - name: Enable specific versions of SSL
   lineinfile:
     dest: /etc/apache2/mods-enabled/ssl.conf


### PR DESCRIPTION
Configure SSLCertificateFile and SSLCertificateKeyFile in mod_ssl. The role assumes you've already installed the certificate files, maybe to a global location like `/etc/ssl`. Then you just pass in the file name to the configuration and it will be installed in the global mod_ssl ssl.conf. Since the role assumes you are installing your own site config, you always have the option to include it in your site config directly.