### PR TITLE
Log client IP address

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -57,6 +57,16 @@ def test_no_indexes(host):
     assert uri['status'] in [403, 404]
 
 
+def test_custom_log_format(host):
+    conf = host.file('/etc/apache2/conf-enabled/custom-log-format.conf')
+
+    assert conf.exists
+    assert conf.user == 'root'
+    assert conf.group == 'root'
+    assert conf.mode == 0o644
+    assert conf.contains('%a')
+
+
 def test_ssl_versions(host):
     mod_ssl = host.file('/etc/apache2/mods-enabled/ssl.conf')
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,6 +88,15 @@
     line: SSLCipherSuite {{ apache2_ssl_ciphers }}
   notify: reload apache
 
+- name: Log client IP address respecting mod_remoteip
+  copy:
+    content: |-
+      LogFormat "%a %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    dest: /etc/apache2/conf-enabled/custom-log-format.conf
+    owner: root
+    group: root
+    mode: 0644
+
 - name: ensure tmpfiles.d exists
   file: dest=/etc/tmpfiles.d mode=0755 owner=root group=root state=directory
 


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1462

We already have mod_remoteip configured, but we need to update the LogFormat so
that it is logging the client IP address rather than the remote IP (which is
always the load balancer).